### PR TITLE
Unlocalized links to go directly to a (possibly) localized page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,6 @@
         margin: 0;
         font-family: "Fira Sans";
         line-height: 1.4em;
-        font-size: 14px;
       }
       h1, h2 {
         font-weight: 800;
@@ -58,12 +57,12 @@
     <article>
       <h2>Build Something Great</h2>
       <a href="http://webmaker-app.mofodev.net/">Try WebMaker Mobile!</a>
-      <a href="https://developer.mozilla.org/en-US/Firefox_OS/Developer_phone_guide/Flame">Developer resources</a>
+      <a href="https://developer.mozilla.org/Firefox_OS/Developer_phone_guide/Flame">Developer resources</a>
       <h2>Flash Your Device</h2>
       <p>Your new Flame is likely running Firefox OS 1.3. If you'd like to update to a newer version, visit the Flashing station on Floor 6.</p>
       <h2>Welcome to Firefox OS</h2>
-      <a href="https://support.mozilla.org/en-US/kb/get-started-firefox-os">Get Started</a>
-      <a href="https://support.mozilla.org/en-US/products/firefox-os">Support</a>
+      <a href="https://support.mozilla.org/kb/get-started-firefox-os">Get Started</a>
+      <a href="https://support.mozilla.org/products/firefox-os">Support</a>
       <a href="http://www.everbuying.com/product549652.html">Buy A Flame</a>
     </article>
   </body>

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
         margin: 0;
         font-family: "Fira Sans";
         line-height: 1.4em;
+        font-size: 16px;
       }
       h1, h2 {
         font-weight: 800;


### PR DESCRIPTION
Remove the 'en-US' or 'en' part in URLs so that readers can get a localized version of SUMO or MDN ;)
